### PR TITLE
https links to github buttons and jQuery CDN libary

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -2,7 +2,7 @@
   <!-- Social links -->
   <ul class="social">
     <li>
-      <iframe class="github-btn" src="http://ghbtns.com/github-btn.html?user=twbs&amp;repo=ratchet&amp;type=watch&amp;count=true" width="100" height="20"></iframe>
+      <iframe class="github-btn" src="https://ghbtns.com/github-btn.html?user=twbs&amp;repo=ratchet&amp;type=watch&amp;count=true" width="100" height="20"></iframe>
     </li>
     <li>
       <a data-ignore="push" href="https://twitter.com/share" class="twitter-share-button" data-url="http://goratchet.com" data-text="Ratchet &#8211; Build mobile apps with simple HTML, CSS, and JS components." data-via="GoRatchet">Tweet</a>
@@ -40,6 +40,8 @@
   }(document, "script", "twitter-wjs"));
 </script>
 
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+<script>window.jQuery || document.write('<script src="https://code.jquery.com/jquery-1.11.3.min.js"><\/script>')</script>
+
 <script src="/dist/js/ratchetPro.min.js"></script>
 <script src="/assets/js/docs.min.js"></script>


### PR DESCRIPTION
https links to github buttons and jQuery CDN library - and added a CDN fallback. This is useful because Google's CDN is blocked in China for example so it would load the jQuery CDN hosted version instead for users there.
